### PR TITLE
Feat/infra vpc s3 secrets bootstrap

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -24,10 +24,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
           cache: 'pnpm'
-
-      - name: Install PNPM
-        run: npm install -g pnpm
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,6 @@ jobs:
     name: CDK Deploy to AWS
     runs-on: ubuntu-latest
 
-    # environment:
-    #   name: production
-    #   url: https://your-domain.com
-
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -23,10 +19,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
           cache: 'pnpm'
-
-      - name: Install pnpm
-        run: npm install -g pnpm
 
       - name: Install Dependencies
         run: pnpm install
@@ -36,7 +34,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1  # or your preferred region
+          aws-region: us-east-1 
 
       - name: Deploy with CDK
         run: pnpm cdk deploy --all --require-approval never

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -1,7 +1,15 @@
 import * as cdk from 'aws-cdk-lib';
 import { AuthStack } from '../lib/auth-stack';
+import { BaseStack } from '../lib/base-stack';
 
 const app = new cdk.App();
+
+new BaseStack(app, 'BaseStack', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION
+  }
+})
 
 new AuthStack(app, 'AuthStack', {
   env: {

--- a/infra/cdk.context.json
+++ b/infra/cdk.context.json
@@ -1,0 +1,10 @@
+{
+  "availability-zones:account=735189763962:region=us-east-1": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+    "us-east-1d",
+    "us-east-1e",
+    "us-east-1f"
+  ]
+}

--- a/infra/lib/base-stack.ts
+++ b/infra/lib/base-stack.ts
@@ -1,0 +1,42 @@
+import { Stack, StackProps, RemovalPolicy } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+
+export class BaseStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    // 🔹 1. VPC with 2 AZs
+    const vpc = new ec2.Vpc(this, 'PlatformVPC', {
+      maxAzs: 2,
+      natGateways: 1,
+    });
+
+    // 🔹 2. S3 Bucket for comic uploads
+    const storageBucket = new s3.Bucket(this, 'ComicMediaBucket', {
+      versioned: true,
+      removalPolicy: RemovalPolicy.DESTROY, // 🔥 change in prod
+      autoDeleteObjects: true, // 🔥 change in prod
+    });
+
+    // 🔹 3. Secrets Manager for DB credentials or API keys
+    const dbSecret = new secretsmanager.Secret(this, 'DatabaseSecret', {
+      secretName: 'nerdwork-db-secret',
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({
+          username: 'nerdwork_admin',
+        }),
+        excludePunctuation: true,
+        includeSpace: false,
+        generateStringKey: 'password',
+      },
+    });
+
+    // Output (optional for testing)
+    this.exportValue(vpc.vpcId, { name: 'VPCId' });
+    this.exportValue(storageBucket.bucketName, { name: 'S3ComicBucket' });
+    this.exportValue(dbSecret.secretArn, { name: 'DBSecretArn' });
+  }
+}

--- a/infra/test/base-stack.test.ts
+++ b/infra/test/base-stack.test.ts
@@ -1,0 +1,13 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { BaseStack } from '../lib/base-stack';
+
+test('BaseStack contains VPC, S3 and Secret', () => {
+  const app = new cdk.App();
+  const stack = new BaseStack(app, 'TestStack');
+  const template = Template.fromStack(stack);
+
+  template.hasResource('AWS::EC2::VPC', {});
+  template.hasResource('AWS::S3::Bucket', {});
+  template.hasResource('AWS::SecretsManager::Secret', {});
+});


### PR DESCRIPTION
# 📝 Description
This PR provisions the foundational infrastructure required for the Nerdwork+ platform. It includes a shared VPC, an S3 bucket for asset storage, and a generated secret in AWS Secrets Manager for future database access.

---

# 📌 Changes Proposed

## 🔍 What were you told to do?
- Provision the foundational environment infrastructure components using CDK
- Set up networking (VPC), file storage (S3), and credential management (Secrets Manager)

## 💪 What I did?
- Created `BaseStack` in `infra/lib/base-stack.ts`
- Added:
  - VPC with 2 Availability Zones
  - S3 bucket (auto-delete in dev)
  - Secret for DB user/password in AWS Secrets Manager
- Linked stack in `bin/infra.ts` for deployment

---

# 🔄 Types of changes
- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [x] Chore  

---

# ✅ Check List

- [x] Follows project conventions and CDK layout
- [x] Secrets and assets are managed securely
- [x] Stack deploys via `pnpm exec cdk deploy BaseStack`
- [x] Added test file for template assertions

---

- VPC: [✅ Created in AWS Console]
- S3: [✅ Versioned bucket visible]
- Secrets Manager: [✅ nerdwork-db-secret exists]
